### PR TITLE
Tweak indentation/alignment cops

### DIFF
--- a/.rubocop-shared.yml
+++ b/.rubocop-shared.yml
@@ -15,12 +15,14 @@ Layout/ClosingParenthesisIndentation:
   Enabled: false
 Layout/DotPosition:
   EnforcedStyle: leading
+Layout/ElseAlignment:
+  Enabled: false
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Layout/EndAlignment:
-  Enabled: true
+  EnforcedStyleAlignWith: variable
 Layout/FirstArgumentIndentation:
-  Enabled: false
+  EnforcedStyle: consistent
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 Layout/LineLength:

--- a/.rubocop-shared.yml
+++ b/.rubocop-shared.yml
@@ -16,11 +16,11 @@ Layout/ClosingParenthesisIndentation:
 Layout/DotPosition:
   EnforcedStyle: leading
 Layout/ElseAlignment:
-  Enabled: false
+  Enabled: true
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Layout/EndAlignment:
-  Enabled: false
+  Enabled: true
 Layout/FirstArgumentIndentation:
   Enabled: false
 Layout/FirstHashElementIndentation:

--- a/.rubocop-shared.yml
+++ b/.rubocop-shared.yml
@@ -15,8 +15,6 @@ Layout/ClosingParenthesisIndentation:
   Enabled: false
 Layout/DotPosition:
   EnforcedStyle: leading
-Layout/ElseAlignment:
-  Enabled: true
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Layout/EndAlignment:
@@ -24,9 +22,7 @@ Layout/EndAlignment:
 Layout/FirstArgumentIndentation:
   Enabled: false
 Layout/FirstHashElementIndentation:
-  Enabled: false
-Layout/IndentationWidth:
-  Enabled: true
+  EnforcedStyle: consistent
 Layout/LineLength:
   Max: 120
   AutoCorrect: true

--- a/.rubocop-shared.yml
+++ b/.rubocop-shared.yml
@@ -26,7 +26,7 @@ Layout/FirstArgumentIndentation:
 Layout/FirstHashElementIndentation:
   Enabled: false
 Layout/IndentationWidth:
-  Enabled: false
+  Enabled: true
 Layout/LineLength:
   Max: 120
   AutoCorrect: true


### PR DESCRIPTION
Firechief
https://www.pivotaltracker.com/story/show/173332675

Before this fix, the following line:
```ruby
    let(:primary_appointment) { create(:appointment, practice: practice, client: primary_client, cpt_codes: [{ code: primary_code.code, number_of_units: 1 }]) }
```

Would be fixed as:
```ruby
    let(:primary_appointment) do
 create(:appointment, practice: practice, client: primary_client,
                      cpt_codes: [{ code: primary_code.code, number_of_units: 1 }])
    end
```

After this fix, it's fixed as:
```ruby
    let(:primary_appointment) do
      create(:appointment, practice: practice, client: primary_client,
                           cpt_codes: [{ code: primary_code.code, number_of_units: 1 }])
    end
```